### PR TITLE
Allow the Omega Dodo from Biomes! Islands to be mounted.

### DIFF
--- a/Patches/patch.owlchemist.giddyup.xml
+++ b/Patches/patch.owlchemist.giddyup.xml
@@ -43,7 +43,6 @@
 					defName="AEXP_Kangaroo" or 
 					defName="VFEI_Insectoid_Megapede" or 
 					defName="AEXP_Moose" or 
-					defName="BiomesIslands_OmegaDodo" or 
 					defName="Pig" or 
 					defName="VFEI_Insectoid_RoyalMegaspider" or 
 					defName="Toxalope" or 


### PR DESCRIPTION
Giddy-Up 2 adds the NotMountable ModExtension to BiomesIslands_OmegaDodo. Now that Biomes! Islands is adding a correct DrawOffset to this animal (https://github.com/biomes-team/BiomesIslands/commit/38911dfc16325892098c44869fb8ae28a41c2f44) this restriction can be removed.